### PR TITLE
Fix signalr interop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ temp/
 .nuget/
 .vs/
 
+.idea/

--- a/src/MessagePack.FSharpExtensions/DiscriminatedUnionResolver.cs
+++ b/src/MessagePack.FSharpExtensions/DiscriminatedUnionResolver.cs
@@ -910,6 +910,8 @@ namespace MessagePack.FSharp.Internal
 
         public static UnionSerializationInfo CreateOrNull(Type type, Microsoft.FSharp.Reflection.UnionCaseInfo caseInfo)
         {
+            type = caseInfo.DeclaringType;
+
             var ti = type.GetTypeInfo();
             var isClass = ti.IsClass;
 

--- a/src/MessagePack.FSharpExtensions/MessagePack.FSharpExtensions.csproj
+++ b/src/MessagePack.FSharpExtensions/MessagePack.FSharpExtensions.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.4.0</Version>
+    <Version>1.4.1</Version>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <Authors>pocketberserker</Authors>
     <Owners>pocketberserker</Owners>


### PR DESCRIPTION
I found an odd behavior when using this library with SignalR.

The SignalR Core library, when sending a message, expects an argument of type `obj`.

When SignalR Core goes to serialize this type, it passes the type of the DU Case, rather than the DU type itself. This is a problem when it comes to discovering the "New" method for the DU case we are trying to serialize or deserialize.

My fix was simply to always re-assign the type in the DiscriminatedUnionResolver to be derived from the UnionCaseInfo. I believe this is always the type expected to be passed in from the outside.

If there is a better way to solve this problem, please let me know, I fixed this for my own purposes and am self-serving the nuget, but thought it might be a welcomed PR.


Other changes:
I added artifacts from the JetBrains line of IDEs to gitignore.
Bumped the NuGet version for the minor fix. 

Fixing whitespace in an upcoming commit 